### PR TITLE
[Fix] Show more than 25 stories

### DIFF
--- a/factory/post.js
+++ b/factory/post.js
@@ -5,11 +5,11 @@ var request = require('request'),
     fs = require('fs'),
     Q = require('q');
 
-var BLOGGER_HOST = 'https://www.blogger.com/feeds/9174986572743472561/posts/default?alt=json';
+var BLOGGER_HOST = 'https://www.blogger.com/feeds/9174986572743472561/posts/default?alt=json&max-results=';
 
 // Fetches data from linda Ikeji's blog
-function fetchTopStories(cb) {
-  request(BLOGGER_HOST, function (err, res) {
+function fetchTopStories(count, cb) {
+  request(BLOGGER_HOST + count, function (err, res) {
     if (!err && res.statusCode == 200) {
       var data = JSON.parse(res.body);
       cb(data);
@@ -17,16 +17,12 @@ function fetchTopStories(cb) {
   });
 }
 
-function getContent(cb) {
-  fetchTopStories(cb);
-}
-
 // Pre processing all the data from the platform
-function processContent(data, count) {
+function processContent(data) {
   var entries = data.feed.entry,
       stories = [];
 
-  for (var i = 0, len = Math.min(count, entries.length); i < len; i++) {
+  for (var i = 0; i < entries.length; i++) {
     var item = entries[i],
         postTitle = item.title.$t,
         content   = item.content.$t,
@@ -51,11 +47,11 @@ function processContent(data, count) {
 function getTrending(count) {
   var deferred = Q.defer();
 
-  getContent(function (res) {
+  fetchTopStories(count, function (res) {
     if (!res) {
       return deferred.reject();
     }
-    var posts = processContent(res, count);
+    var posts = processContent(res);
       deferred.resolve(posts);
   });
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ program
   .description('List Linda Ikeji Top Stories')
   .option('-n, --number <int>", "specify number of stories')
   .action(function(options){
-    var count = (typeof options === 'object' || isNaN(parseInt(options)) || parseInt(options) == 0) ? 20 : options;
+    var count = isNaN(parseInt(options) || parseInt(options) == 0) ? 20 : options;
     console.log("List top " + count + " Linda Ikeji Stories");
     list.top(count);
   });

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ program
   .description('List Linda Ikeji Top Stories')
   .option('-n, --number <int>", "specify number of stories')
   .action(function(options){
-    var count = (typeof options === 'object') ? 20 : options;
+    var count = (typeof options === 'object' || isNaN(parseInt(options)) || parseInt(options) == 0) ? 20 : options;
     console.log("List top " + count + " Linda Ikeji Stories");
     list.top(count);
   });


### PR DESCRIPTION
- Remove redundant function `getContent` in `post.js`
- Add `max-results` query argument as part of `BLOGGER_HOST` string url
- `fetchTopStories` now accepts `count` as an argument
- Remove `count` as `processContent` argument and update `for` loop condition
